### PR TITLE
Make python3 build optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 all: build develop
 
+python3: build3 develop3
+
 build:
 	python2 setup.py build
+
+build3:
 	python3 setup.py build
 
 clean:
@@ -12,10 +16,14 @@ realclean: clean
 
 tests:
 	nosetests
+
+test3:
 	nosetests3
 
 develop:
 	python2 setup.py develop
+
+develop3:
 	python3 setup.py develop
 
-.PHONY: clean realclean tests develop build
+.PHONY: clean realclean tests tests3 develop develop3 build build3

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -19,8 +19,16 @@ class ads-tracking {
     command => 'make',
     require => [
       Package['python-setuptools'],
-      Package['python3-setuptools'],
       Package['python-baseplate'],
+    ],
+  }
+
+  # Set up the app
+  exec { 'install-app3':
+    cwd     => $project_path,
+    command => 'make python3',
+    require => [
+      Package['python3-setuptools'],
       Package['python3-baseplate'],
     ],
   }


### PR DESCRIPTION
👓 @spladug 

logs to confirm things work:

vagrant:

```
➜  ads-tracking git:(make3) ✗ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Removing hosts
==> default: No machine id, nothing removed from /etc/hosts
==> default: Importing base box 'trusty-cloud-image'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: ads-tracking_default_1470252022773_29539
==> default: Clearing any previously set forwarded ports...
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 9090 (guest) => 9090 (host) (adapter 1)
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Checking for host entries
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 4.3.34
    default: VirtualBox Version: 5.0
==> default: Setting hostname...
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
    default: /home/vagrant/src => /Users/dwick/work/code/ads/ads-tracking
    default: /tmp/vagrant-puppet/modules-724790ec96fa5bfbe8aadfa8de535d2b => /Users/dwick/work/code/ads/ads-tracking/puppet/modules
    default: /tmp/vagrant-puppet/manifests-846018e2aa141a5eb79a64b4015fc5f3 => /Users/dwick/work/code/ads/ads-tracking/puppet/manifests
==> default: Running provisioner: puppet...
==> default: Running Puppet with init.pp...
==> default: stdin: is not a tty
==> default: Notice: Compiled catalog for ads-tracking.vm in environment production in 0.21 seconds
==> default: Notice: /Stage[main]/Packages/Exec[reddit-repo-add]/returns: executed successfully
==> default: Notice: /Stage[main]/Packages/Exec[update-apt]: Triggered 'refresh' from 1 events
==> default: Notice: /Stage[main]/Packages/Package[python-webtest]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-pyramid]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-pip]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-baseplate]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-mock]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[einhorn]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python3-nose]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python3-mock]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python3-setuptools]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-dev]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-httpagentparser]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-nose]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python3-webtest]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-coverage]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Ads-tracking/Exec[install-app]/returns: executed successfully
==> default: Notice: /Stage[main]/Packages/Package[python3-coverage]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python3-baseplate]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Packages/Package[python-gevent]/ensure: ensure changed 'purged' to 'present'
==> default: Notice: /Stage[main]/Ads-tracking/Exec[install-app3]/returns: executed successfully
==> default: Notice: /Stage[main]/Events/File[/etc/security/limits.d/message-queues.conf]/ensure: defined content as '{md5}968b0add7b18474ba3131ddab41a48cb'
==> default: Notice: /Stage[main]/Events/File[/etc/sysctl.d/60-message-queues.conf]/ensure: defined content as '{md5}eb72b05772aaab954388602749e6c5e3'
==> default: Notice: /Stage[main]/Events/Exec[reload sysctls]: Triggered 'refresh' from 1 events
==> default: Notice: /Stage[main]/Events/Events::Consumer[production]/File[/etc/init/events-discard-production.conf]/ensure: defined content as '{md5}1198e47a0fdf6ad88263025bcd89ce8d'
==> default: Notice: /Stage[main]/Events/Events::Consumer[production]/Service[events-discard-production]/ensure: ensure changed 'stopped' to 'running'
==> default: Notice: Finished catalog run in 200.30 seconds
```

make:

```
vagrant@ads-tracking:~/src$ sudo make
python2 setup.py build
running build
running build_py
running build_thrift
python2 setup.py develop
running develop
running egg_info
writing requirements to reddit_service_ads_tracking.egg-info/requires.txt
writing reddit_service_ads_tracking.egg-info/PKG-INFO
writing top-level names to reddit_service_ads_tracking.egg-info/top_level.txt
writing dependency_links to reddit_service_ads_tracking.egg-info/dependency_links.txt
reading manifest file 'reddit_service_ads_tracking.egg-info/SOURCES.txt'
writing manifest file 'reddit_service_ads_tracking.egg-info/SOURCES.txt'
running build_ext
Creating /usr/local/lib/python2.7/dist-packages/reddit-service-ads-tracking.egg-link (link to .)
reddit-service-ads-tracking 0.0.0 is already the active version in easy-install.pth

Installed /home/vagrant/src
Processing dependencies for reddit-service-ads-tracking==0.0.0
Searching for baseplate==0.13.0
Best match: baseplate 0.13.0
baseplate 0.13.0 is already the active version in easy-install.pth
Installing baseplate-healthcheck2 script to /usr/local/bin

Using /usr/lib/python2.7/dist-packages
Searching for pyramid==1.4.5
Best match: pyramid 1.4.5
pyramid 1.4.5 is already the active version in easy-install.pth
Installing ptweens script to /usr/local/bin
Installing proutes script to /usr/local/bin
Installing pshell script to /usr/local/bin
Installing prequest script to /usr/local/bin
Installing pviews script to /usr/local/bin
Installing bfg2pyramid script to /usr/local/bin
Installing pcreate script to /usr/local/bin
Installing pserve script to /usr/local/bin

Using /usr/lib/python2.7/dist-packages
Searching for enum34==0.9.23
Best match: enum34 0.9.23
enum34 0.9.23 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for posix-ipc==1.0.0
Best match: posix-ipc 1.0.0
posix-ipc 1.0.0 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for requests==2.2.1
Best match: requests 2.2.1
requests 2.2.1 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for PasteDeploy==1.5.2
Best match: PasteDeploy 1.5.2
PasteDeploy 1.5.2 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for translationstring==1.1
Best match: translationstring 1.1
translationstring 1.1 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for venusian==1.0a8
Best match: venusian 1.0a8
venusian 1.0a8 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for zope.deprecation==4.0.2
Best match: zope.deprecation 4.0.2
zope.deprecation 4.0.2 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for zope.interface==4.0.5
Best match: zope.interface 4.0.5
zope.interface 4.0.5 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for repoze.lru==0.6
Best match: repoze.lru 0.6
repoze.lru 0.6 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for WebOb==1.3.1
Best match: WebOb 1.3.1
WebOb 1.3.1 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for Mako==0.9.1
Best match: Mako 0.9.1
Mako 0.9.1 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for Chameleon==2.6.1
Best match: Chameleon 2.6.1
Chameleon 2.6.1 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Searching for MarkupSafe==0.18
Best match: MarkupSafe 0.18
MarkupSafe 0.18 is already the active version in easy-install.pth

Using /usr/lib/python2.7/dist-packages
Finished processing dependencies for reddit-service-ads-tracking==0.0.0
```
