### PR TITLE
Fix blank query values being modifed when encoding them

### DIFF
--- a/reddit_service_ads_tracking/lib/urls.py
+++ b/reddit_service_ads_tracking/lib/urls.py
@@ -1,10 +1,30 @@
 import urllib
 
 from urlparse import (
-    parse_qsl,
     urlparse,
-    urlunparse,
 )
+
+
+def _encode_query(query):
+    """
+    `urlparse.parse_qsl` and `urllib.encodeurl` modify
+    blank query values so we had to roll our own.
+    """
+    kvps = urllib.unquote_plus(query).split("&")
+    encoded_pairs = []
+
+    for kvp in kvps:
+        if "=" not in kvp:
+            encoded_pairs.append(urllib.quote_plus(kvp))
+        else:
+            key, value = kvp.split("=")
+            encoded_pairs.append("%s=%s" % (
+                urllib.quote_plus(key),
+                urllib.quote_plus(value)
+            ))
+
+    return "&".join(encoded_pairs)
+
 
 
 def fix_query_encoding(url):
@@ -12,14 +32,9 @@ def fix_query_encoding(url):
 
     parsed = urlparse(url)
     if parsed.query:
-        query_params = parse_qsl(
-            parsed.query,
-            keep_blank_values=True,
-        )
-
         # this effectively calls urllib.quote_plus on every query value
         parsed = parsed._replace(
-            query=urllib.urlencode(query_params)
+            query=_encode_query(parsed.query)
         )
 
     return parsed.geturl()

--- a/tests/unit/lib/urls_tests.py
+++ b/tests/unit/lib/urls_tests.py
@@ -30,11 +30,22 @@ class UrlsTests(unittest.TestCase):
         self.assertEqual(urls.fix_query_encoding(url), url)
 
     def test_fix_query_encoding_retains_blank_values(self):
-        url = "https://example.com?foo="
+        url1 = "https://example.com?foo=&bar=bing"
+        url2 = "https://example.com?foo="
+        url3 = "https://example.com?bar=bing&foo="
 
-        self.assertEqual(urls.fix_query_encoding(url), url)
+        self.assertEqual(urls.fix_query_encoding(url1), url1)
+        self.assertEqual(urls.fix_query_encoding(url2), url2)
+        self.assertEqual(urls.fix_query_encoding(url3), url3)
 
-        self.assertEqual(urls.fix_query_encoding(url), url)
+    def test_fix_query_encoding_retains_blank_values_without_equals(self):
+        url1 = "https://example.com?foo&bar=bing"
+        url2 = "https://example.com?foo"
+        url3 = "https://example.com?bar=bing&foo"
+
+        self.assertEqual(urls.fix_query_encoding(url1), url1)
+        self.assertEqual(urls.fix_query_encoding(url2), url2)
+        self.assertEqual(urls.fix_query_encoding(url3), url3)
 
     def test_fix_query_encoding_encodes_values(self):
         url = "https://example.com?url=http://example.com&foo=bar"


### PR DESCRIPTION
`urls.fix_query_encoding` should not modify blank query values.
the usage of `urlparse.parse_qsl` and `urllib.encodeurl` was
causing the following url:
  https://example.com?foo&bar=bing
to be modified to:
  https://example.com?foo=&bar=bing

👓 @aoiwelle 

ticket: https://reddit.atlassian.net/browse/ADS-789
