### PR TITLE
Add drone CI config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,9 @@
+build:
+  image: reddit/reddit-py
+  pull: true
+  commands:
+    - sudo apt-get update -q
+    - sudo apt-get install -y puppet
+    - sudo puppet apply puppet/manifests/init.pp --modulepath=puppet/modules
+    - ulimit -q
+    - sudo nosetests


### PR DESCRIPTION
👓 @gtaylor 

Not sure if this is correct.  It's just a baseplate service so i think `reddit/reddit-py` is the correct image.

Can you also enable drone for this repo?
